### PR TITLE
Add flag to ManagedProcess to denote that the process was destroyed before alloted exit time

### DIFF
--- a/src/main/java/ch/vorburger/exec/ManagedProcess.java
+++ b/src/main/java/ch/vorburger/exec/ManagedProcess.java
@@ -366,6 +366,15 @@ public class ManagedProcess implements ManagedProcessState {
     }
 
     /**
+     * Signifies whether the ManagedProcess was destroyed ({@link ManagedProcess#destroy()}) was called on this
+     * process.
+     * @return whether this process was destroyed or not.
+     */
+    public boolean wasDestroyed() {
+        return destroyed;
+    }
+
+    /**
      * Allows <CODE>LoggingExecuteResultHandler</CODE> to notify if process has halted (success or failure)
      */
     @Override

--- a/src/main/java/ch/vorburger/exec/ManagedProcess.java
+++ b/src/main/java/ch/vorburger/exec/ManagedProcess.java
@@ -529,8 +529,4 @@ public class ManagedProcess implements ManagedProcessState {
                 + (executor.getWorkingDirectory() == null ? "" : " (in working directory "
                         + executor.getWorkingDirectory().getAbsolutePath() + ")");
     }
-
-    public boolean wasDestroyed() {
-        return destroyed;
-    }
 }

--- a/src/main/java/ch/vorburger/exec/ManagedProcess.java
+++ b/src/main/java/ch/vorburger/exec/ManagedProcess.java
@@ -81,6 +81,7 @@ public class ManagedProcess implements ManagedProcessState {
     private boolean isAlive = false;
     private String procShortName;
     private RollingLogOutputStream console;
+    private boolean destroyed = false;
 
     /**
      * Package local constructor.
@@ -336,7 +337,6 @@ public class ManagedProcess implements ManagedProcessState {
         }
 
         watchDog.destroyProcess();
-
         try {
             // Safer to waitFor() after destroy()
             resultHandler.waitFor();
@@ -349,6 +349,7 @@ public class ManagedProcess implements ManagedProcessState {
         }
 
         isAlive = false;
+        destroyed = true;
     }
 
     // Java Doc shamelessly copy/pasted from java.lang.Thread#isAlive() :
@@ -518,5 +519,9 @@ public class ManagedProcess implements ManagedProcessState {
                 + commandLine.toString()
                 + (executor.getWorkingDirectory() == null ? "" : " (in working directory "
                         + executor.getWorkingDirectory().getAbsolutePath() + ")");
+    }
+
+    public boolean wasDestroyed() {
+        return destroyed;
     }
 }

--- a/src/test/java/ch/vorburger/exec/ManagedProcessTest.java
+++ b/src/test/java/ch/vorburger/exec/ManagedProcessTest.java
@@ -66,6 +66,7 @@ public class ManagedProcessTest {
         assertThat(p.isAlive(), is(false));
         try {
             p.destroy();
+            assertThat(p.wasDestroyed(), is(true));
             Assert.fail("ManagedProcess.destroy() should have thrown a ManagedProcessException here");
         } catch (@SuppressWarnings("unused") ManagedProcessException e) {
             // as expected
@@ -156,10 +157,12 @@ public class ManagedProcessTest {
         p.waitForExit();
         p.exitValue(); // just making sure it works, don't check, as Win/NIX diff.
         assertThat(p.isAlive(), is(false));
+        assertThat(p.wasDestroyed(), is(false)); // process was not destroyed because it finished gracefully
 
         // It's NOT OK to call destroy() on a process which already terminated
         try {
             p.destroy();
+            assertThat(p.wasDestroyed(), is(true));
             Assert.fail("Should have thrown an ManagedProcessException");
         } catch (@SuppressWarnings("unused") ManagedProcessException e) {
             // as expected

--- a/src/test/java/ch/vorburger/exec/ManagedProcessTest.java
+++ b/src/test/java/ch/vorburger/exec/ManagedProcessTest.java
@@ -134,6 +134,15 @@ public class ManagedProcessTest {
     }
 
     @Test
+    public void testProcessExitsGracefullyWhenFinishesBelowMaxWaitTime() throws ManagedProcessException {
+        ManagedProcess process = new ManagedProcessBuilder("sleep").addArgument(".01s").build();
+        process.start();
+        process.waitForExitMaxMsOrDestroy(50);
+        assertThat(process.isAlive(), is(false));
+        assertThat(process.wasDestroyed(), is(false));
+    }
+
+    @Test
     public void testSelfTerminatingExec() throws Exception {
         SomeSelfTerminatingExec exec = someSelfTerminatingExec();
         ManagedProcess p = exec.proc;
@@ -223,6 +232,7 @@ public class ManagedProcessTest {
         assertThat(p.isAlive(), is(true));
         p.waitForExitMaxMsOrDestroy(200);
         assertThat(p.isAlive(), is(false));
+        assertThat(p.wasDestroyed(), is(true));
         // can not: p.exitValue();
     }
 


### PR DESCRIPTION
WatchDog does not set a flag when a process is destroyed (regardless of what it claims), so this PR adds a custom flag to denote whether it was destroyed.