### PR TITLE
Add automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,18 @@
         </configuration>
       </plugin>
       <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+          <configuration>
+          <archive>
+              <manifestEntries>
+                  <Automatic-Module-Name>ch.vorburger.exec</Automatic-Module-Name>
+              </manifestEntries>
+          </archive>
+          </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <version>1.6.8</version>


### PR DESCRIPTION
Libraries without a set automatic module name causes build warnings for
all clients who build with Java >= 9.

This change is made to solve the following issue for MariaDB4J:
https://github.com/vorburger/MariaDB4j/issues/372