### PR TITLE
Fix broken support for arguments with spaces on Linux

### DIFF
--- a/src/main/java/ch/vorburger/exec/ManagedProcessBuilder.java
+++ b/src/main/java/ch/vorburger/exec/ManagedProcessBuilder.java
@@ -144,7 +144,7 @@ public class ManagedProcessBuilder {
         // and it contains a space, so it re-escapes it, causing applications such as mysqld.exe to split
         // it into multiple pieces, which is why we quote the whole arg (key and value) instead.
         // We do this trick only on Windows, because on Linux it breaks the behavior.
-        if ("=".equals(separator) && isWindows()) {
+        if (isWindows()) {
             sb.append(argPart1);
             sb.append(separator);
             sb.append(argPart2);


### PR DESCRIPTION
It was broken in 1b71a28d41b3d7df6864d44c36b6aa85cfa2d765.

See https://github.com/vorburger/ch.vorburger.exec/pull/58
for https://github.com/vorburger/MariaDB4j/issues/501.
