### PR TITLE
Fix for https://github.com/vorburger/MariaDB4j/issues/233

### DIFF
--- a/src/main/java/ch/vorburger/exec/ManagedProcess.java
+++ b/src/main/java/ch/vorburger/exec/ManagedProcess.java
@@ -67,7 +67,7 @@ public class ManagedProcess implements ManagedProcessState {
 
     private final CommandLine commandLine;
     private final Executor executor = new DefaultExecutor();
-    private final ExecuteWatchdog watchDog = new ExecuteWatchdog(ExecuteWatchdog.INFINITE_TIMEOUT);
+    private final StopCheckExecuteWatchdog watchDog = new StopCheckExecuteWatchdog(ExecuteWatchdog.INFINITE_TIMEOUT);
     private final ProcessDestroyer shutdownHookProcessDestroyer = new LoggingShutdownHookProcessDestroyer();
     private final Map<String, String> environment;
     private final CompositeExecuteResultHandler resultHandler;
@@ -473,7 +473,7 @@ public class ManagedProcess implements ManagedProcessState {
     }
 
     protected void assertWaitForIsValid() throws ManagedProcessException {
-        if (!isAlive() && !resultHandler.hasResult()) {
+        if (!watchDog.isStopped() && !isAlive() && !resultHandler.hasResult()) {
             throw new ManagedProcessException("Asked to waitFor " + getProcLongName()
                     + ", but it was never even start()'ed!");
         }

--- a/src/main/java/ch/vorburger/exec/StopCheckExecuteWatchdog.java
+++ b/src/main/java/ch/vorburger/exec/StopCheckExecuteWatchdog.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * ch.vorburger.exec
+ * %%
+ * Copyright (C) 2012 - 2018 Michael Vorburger
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package ch.vorburger.exec;
+
+import org.apache.commons.exec.ExecuteWatchdog;
+
+public class StopCheckExecuteWatchdog extends ExecuteWatchdog {
+    private volatile boolean stopped = false;
+
+    /**
+     * Creates a new watchdog with a given timeout.
+     *
+     * @param timeout
+     *         the timeout for the process in milliseconds. It must be
+     *         greater than 0 or 'INFINITE_TIMEOUT'
+     */
+    public StopCheckExecuteWatchdog(long timeout) {
+        super(timeout);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void stop() {
+        super.stop();
+        stopped = true;
+    }
+
+    public boolean isStopped() {
+        return stopped;
+    }
+}


### PR DESCRIPTION
Hi,

A fix/mitigation for https://github.com/vorburger/MariaDB4j/issues/233

https://github.com/vorburger/MariaDB4j/issues/233#issuecomment-1131559138 and https://github.com/vorburger/MariaDB4j/issues/233#issuecomment-1258651583 pointed in the right direction, but that seems not to be the actual issue. `ExecuteWatchdog#isWatching()` calls `ExecuteWatchdog#ensureStarted()`, which blocks until `ExecuteWatchdog#start(Process)` is called by the `DefaultExecutor` in `executeInternal(...)`.

The issue appears to be the opposite - the process completes so quickly that `isAlive` in `ManagedProcess` is never set to true because by the time `isAlive = watchDog.isWatching()` is called, the process already completed.

The `or already finished` part in the comment
```java
// watchDog.isWatching() blocks if the process never started or already finished,
```
isn't true I think?