### PR TITLE
volatile isAlive (fixes #99)

### DIFF
--- a/src/main/java/ch/vorburger/exec/ManagedProcess.java
+++ b/src/main/java/ch/vorburger/exec/ManagedProcess.java
@@ -78,7 +78,7 @@ public class ManagedProcess implements ManagedProcessState {
     private final MultiOutputStream stdouts;
     private final MultiOutputStream stderrs;
 
-    private boolean isAlive = false;
+    private volatile boolean isAlive = false;
     private String procShortName;
     private RollingLogOutputStream console;
 


### PR DESCRIPTION
Problem
=======

There's a potential thread safety violation where different threads could be reading and writing to the `isAlive` field without synchronization.  See #99 

Solution
========

It seems like it's safe to race on isAlive, so we don't necessarily need to add synchronization.  Instead, we will continue to permit racing on isAlive but will ensure that publication is safe by marking it as volatile.

Result
======

Publication will always happen.  This should hopefully unblock #96.