### PR TITLE
Enforce Java 8 JDK API only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <!-- Keep these versions aligned with .github/workflows/maven.yml -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>8</maven.compiler.release>
         <error-prone.version>2.19.1</error-prone.version>
     </properties>
 
@@ -70,9 +70,7 @@
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>-Xplugin:ErrorProne -XepAllDisabledChecksAsWarnings
                             -Xep:BooleanParameter:OFF -Xep:AndroidJdkLibsChecker:OFF
-                            -Xep:Java7ApiChecker:OFF -Xep:Java8ApiChecker:OFF -Xep:Varifier:OFF</arg>
-                        <!-- TODO https://github.com/vorburger/ch.vorburger.exec/issues/117 remove
-                        Java8ApiChecker if going back to Java 8 -->
+                            -Xep:Java7ApiChecker:OFF -Xep:Varifier:OFF</arg>
                         <!-- TODO Remove Varifier when switching from 8 to Java 11 -->
                     </compilerArgs>
                     <annotationProcessorPaths>

--- a/src/main/java/ch/vorburger/exec/ManagedProcessBuilder.java
+++ b/src/main/java/ch/vorburger/exec/ManagedProcessBuilder.java
@@ -19,6 +19,9 @@
  */
 package ch.vorburger.exec;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.File;
 import java.io.IOException;
@@ -183,7 +186,8 @@ public class ManagedProcessBuilder {
     }
 
     public List<String> getArguments() {
-        return List.of(commonsExecCommandLine.getArguments());
+        // TODO When moving to Java 11+ then replace with List.of()
+        return unmodifiableList(asList(commonsExecCommandLine.getArguments()));
     }
 
     /**


### PR DESCRIPTION
@mosesn do you want this? Re. #117. -- I am happy to & don't really mind!

PS: If you do not need this, I would prefer and find it clearer if we "fully" updated to Java 11.