### PR TITLE
osx friendly tests

### DIFF
--- a/src/test/java/ch/vorburger/exec/ManagedProcessTest.java
+++ b/src/test/java/ch/vorburger/exec/ManagedProcessTest.java
@@ -64,7 +64,11 @@ public class ManagedProcessTest {
         TestListener listener = new TestListener();
         SomeSelfTerminatingExec exec = someSelfTerminatingFailingExec(listener, true);
         exec.proc.startAndWaitForConsoleMessageMaxMs(exec.msgToWaitFor, 1000);
-        assertEquals(2, listener.expectedExitValue);
+        if (SystemUtils.IS_OS_MAC) {
+            assertEquals(1, listener.expectedExitValue);
+        } else { // assumes linux
+            assertEquals(2, listener.expectedExitValue);
+        }
         assertEquals(Integer.MIN_VALUE, listener.failureExitValue);
         assertNull(listener.t);
     }
@@ -202,7 +206,11 @@ public class ManagedProcessTest {
             pb = new ManagedProcessBuilder("notepad.exe");
         } else {
             pb = new ManagedProcessBuilder("sleep");
-            pb.addArgument("30s");
+            if (SystemUtils.IS_OS_MAC) {
+                pb.addArgument("30");
+            } else { // assume linux
+                pb.addArgument("30s");
+            }
         }
 
         ManagedProcess p = pb.build();


### PR DESCRIPTION
The ManagedProcessTest relies on the executables that are commonly found on different OSes.  Although many of the BSD and Linux executables are similar, they have some minor differences.  For example, ls -4 returns with an exit code of 2 on OSX, not 1 like on Linux. Similarly, sleep just takes a number of seconds on OSX, unlike on Linux where it also takes a unit (eg 10s or 10ms).

This patch updates the tests to accommodate the different behavior in OSX.