### PR TITLE
Increment project's version from 3.2.1-SNAPSHOT to 3.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>ch.vorburger.exec</groupId>
   <artifactId>exec</artifactId>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
 
   <name>ch.vorburger.exec</name>
   <description>Java library to launch external processes</description>


### PR DESCRIPTION
Because upcoming #126 removes `AtomicExecuteResultHandler` and `LoggingExecuteResultHandler`, which were public API, it seems appropriate to increase the version.

@mosesn FYI