### PR TITLE
Only run CodeQL for pull_request, not push

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,6 +36,7 @@ jobs:
             ${{ runner.os }}-m2
 
       - name: Initialize CodeQL
+        if: github.event_name == 'pull_request'
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
@@ -44,4 +45,5 @@ jobs:
         run: mvn --batch-mode --update-snapshots package --file pom.xml
 
       - name: Perform CodeQL Analysis
+        if: github.event_name == 'pull_request'
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
This will hopefully fix this:

Uploading results
  Warning: Resource not accessible by integration
  Error: Resource not accessible by integration
  Warning: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#scanning-on-push for more information on how to configure these events.