### PR TITLE
build: Remove ErrorProne -Xep:Java7ApiChecker:OFF from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
             <arg>--should-stop=ifError=FLOW</arg>
             <arg>-Xplugin:ErrorProne -XepAllDisabledChecksAsWarnings
               -Xep:BooleanParameter:OFF -Xep:AndroidJdkLibsChecker:OFF
-              -Xep:Java7ApiChecker:OFF -Xep:Varifier:OFF</arg>
+              -Xep:Varifier:OFF</arg>
             <!-- TODO Remove Varifier when switching from 8 to Java 11 -->
           </compilerArgs>
           <annotationProcessorPaths>


### PR DESCRIPTION
This check has been removed in Error Prone 2.38.0, and its presence here prevents upgrading to that newer version in #261.