### PR TITLE
Replace Apache Commons Collections dependency with simple local CircularFifoQueue alternative (fixes #263)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,12 +267,6 @@
       <version>1.4.0</version>
     </dependency>
     <dependency>
-      <!-- Just for its CircularFifoQueue... -->
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>4.5.0</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/src/main/java/ch/vorburger/exec/CircularFifoQueue.java
+++ b/src/main/java/ch/vorburger/exec/CircularFifoQueue.java
@@ -1,0 +1,145 @@
+/*
+ * #%L
+ * ch.vorburger.exec
+ * %%
+ * Copyright (C) 2012 - 2025 Michael Vorburger
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ch.vorburger.exec;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * A circular FIFO queue that stores a fixed number of elements.
+ * When the queue is full, adding a new element removes the oldest element.
+ * This class implements {@code java.util.Collection} to allow iteration,
+ * specifically for the {@code getRecentLines()} method in {@code RollingLogOutputStream}.
+ *
+ * @param <E> the type of elements held in this collection
+ * @author Jules (jules.google.com)
+ */
+class CircularFifoQueue<E> implements Collection<E> {
+
+    private final int maxSize;
+    private final ArrayDeque<E> queue;
+
+    public CircularFifoQueue(int maxSize) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("The maxSize must be greater than 0");
+        }
+        this.maxSize = maxSize;
+        // Initialize with a capacity of maxSize to avoid reallocations up to that point,
+        // though ArrayDeque will grow beyond this if more elements are added temporarily
+        // before being removed.
+        this.queue = new ArrayDeque<>(maxSize);
+    }
+
+    @Override
+    public boolean add(E item) {
+        if (item == null) {
+            // ArrayDeque does not permit null elements, matching behavior of many queue impls.
+            // Throwing an NPE is consistent with what ArrayDeque.add() would do.
+            throw new NullPointerException("Item cannot be null");
+        }
+        if (queue.size() >= maxSize) {
+            queue.pollFirst(); // remove a head element if the queue is full
+        }
+        return queue.offerLast(item); // add to tail, returns false if queue is full (capacity-restricted)
+                                      // but our manual pollFirst ensures this won't happen unless
+                                      // maxSize is 0, which is guarded by constructor.
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        // Return a wrapper iterator that does not support remove()
+        return new Iterator<E>() {
+            private final Iterator<E> delegate = queue.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return delegate.hasNext();
+            }
+
+            @Override
+            public E next() {
+                return delegate.next();
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    // The following methods are not supported and throw UnsupportedOperationException
+
+    @Override
+    public int size() {
+        return queue.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object[] toArray() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/ch/vorburger/exec/RollingLogOutputStream.java
+++ b/src/main/java/ch/vorburger/exec/RollingLogOutputStream.java
@@ -19,8 +19,6 @@
  */
 package ch.vorburger.exec;
 
-import java.util.Collection;
-import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.exec.LogOutputStream;
 
 /**
@@ -31,7 +29,7 @@ import org.apache.commons.exec.LogOutputStream;
 // intentionally package local for now
 class RollingLogOutputStream extends LogOutputStream {
 
-    private final Collection<String> ringBuffer;
+    private final CircularFifoQueue<String> ringBuffer;
 
     RollingLogOutputStream(int maxLines) {
         ringBuffer = new CircularFifoQueue<>(maxLines);

--- a/src/test/java/ch/vorburger/exec/CircularFifoQueueTest.java
+++ b/src/test/java/ch/vorburger/exec/CircularFifoQueueTest.java
@@ -1,0 +1,220 @@
+/*
+ * #%L
+ * ch.vorburger.exec
+ * %%
+ * Copyright (C) 2012 - 2025 Michael Vorburger
+ * Copyright (C) 2025 Jules (jules.google.com)
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ch.vorburger.exec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.Test;
+
+/**
+ * Tests CircularFifoQueue.
+ *
+ * @author Michael Vorburger
+ * @author Jules (jules.google.com)
+ */
+public class CircularFifoQueueTest {
+
+    @Test
+    public void initialization() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
+        assertTrue("Queue should be empty upon initialization", queue.isEmpty());
+        assertEquals("Queue should have size 0 upon initialization", 0, queue.size());
+        // Test initialization with invalid capacity
+        assertThrows(IllegalArgumentException.class, () -> new CircularFifoQueue<>(0));
+        assertThrows(IllegalArgumentException.class, () -> new CircularFifoQueue<>(-1));
+    }
+
+    @Test
+    public void isEmpty() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
+        assertTrue("New queue should be empty", queue.isEmpty());
+        assertEquals("New queue should have size 0", 0, queue.size());
+
+        queue.add("item1");
+        assertFalse("Queue with one item should not be empty", queue.isEmpty());
+        assertEquals("Queue with one item should have size 1", 1, queue.size());
+
+        queue.add("item2");
+        queue.add("item3"); // Queue is full
+        assertFalse("Full queue should not be empty", queue.isEmpty());
+        assertEquals("Full queue should have size 3", 3, queue.size());
+
+        queue.add("item4"); // item1 is evicted
+        assertFalse("Queue after rolling should not be empty", queue.isEmpty());
+        assertEquals("Queue after rolling should have size 3", 3, queue.size());
+    }
+
+    @Test
+    public void addAndFull() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
+        assertTrue(queue.add("one"));
+        assertEquals(1, queue.size());
+        assertTrue(queue.add("two"));
+        assertEquals(2, queue.size());
+        assertTrue(queue.add("three"));
+        assertEquals(3, queue.size());
+
+        // Queue is full, iterator should have 3 elements
+        @SuppressWarnings("Var") Iterator<String> it = queue.iterator();
+        assertTrue(it.hasNext());
+        assertEquals("one", it.next());
+        assertTrue(it.hasNext());
+        assertEquals("two", it.next());
+        assertTrue(it.hasNext());
+        assertEquals("three", it.next());
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void rollingBehavior() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
+        queue.add("1");
+        queue.add("2");
+        queue.add("3");
+        assertEquals(3, queue.size()); // Full
+
+        queue.add("4"); // "1" should be evicted
+        assertEquals(3, queue.size());
+        List<String> items = new ArrayList<>();
+        for (String item : queue) {
+            items.add(item);
+        }
+        assertEquals(Arrays.asList("2", "3", "4"), items);
+
+        queue.add("5"); // "2" should be evicted
+        assertEquals(3, queue.size());
+        items.clear();
+        for (String item : queue) {
+            items.add(item);
+        }
+        assertEquals(Arrays.asList("3", "4", "5"), items);
+    }
+
+    @Test
+    public void iteratorOrder() {
+        CircularFifoQueue<Integer> queue = new CircularFifoQueue<>(5);
+        List<Integer> expected = new ArrayList<>();
+
+        for (int i = 1; i <= 3; i++) {
+            queue.add(i);
+            expected.add(i);
+        }
+
+        List<Integer> actual = new ArrayList<>();
+        for (Integer item : queue) {
+            actual.add(item);
+        }
+        assertEquals("Iterator should return elements in FIFO order (partially full)", expected, actual);
+
+        queue.add(4);
+        expected.add(4);
+        queue.add(5);
+        expected.add(5); // Queue is now full: [1, 2, 3, 4, 5]
+
+        actual.clear();
+        for (Integer item : queue) {
+            actual.add(item);
+        }
+        assertEquals("Iterator should return elements in FIFO order (full)", expected, actual);
+
+        queue.add(6); // Evicts 1, queue: [2, 3, 4, 5, 6]
+        expected.remove(0);
+        expected.add(6);
+
+        actual.clear();
+        for (Integer item : queue) {
+            actual.add(item);
+        }
+        assertEquals("Iterator should return elements in FIFO order (after rolling)", expected, actual);
+    }
+
+    @Test
+    public void maxSizeOne() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(1);
+        queue.add("A");
+        assertEquals(1, queue.size());
+        @SuppressWarnings("Var") Iterator<String> it = queue.iterator();
+        assertTrue(it.hasNext());
+        assertEquals("A", it.next());
+        assertFalse(it.hasNext());
+
+        queue.add("B"); // "A" should be evicted
+        assertEquals(1, queue.size());
+        it = queue.iterator();
+        assertTrue(it.hasNext());
+        assertEquals("B", it.next());
+        assertFalse(it.hasNext());
+
+        queue.add("C"); // "B" should be evicted
+        assertEquals(1, queue.size());
+        it = queue.iterator();
+        assertTrue(it.hasNext());
+        assertEquals("C", it.next());
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void addNull() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
+        assertThrows(NullPointerException.class, () -> queue.add(null));
+    }
+
+    @Test
+    public void unsupportedOperations() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
+        queue.add("test");
+
+        // size() and isEmpty() are now supported, so they are removed from this test.
+        assertThrows(UnsupportedOperationException.class, () -> queue.contains("test"));
+        assertThrows(UnsupportedOperationException.class, () -> queue.toArray());
+        assertThrows(UnsupportedOperationException.class, () -> queue.toArray(new String[0]));
+        assertThrows(UnsupportedOperationException.class, () -> queue.remove("test"));
+        assertThrows(UnsupportedOperationException.class, () -> queue.containsAll(Arrays.asList("test")));
+        assertThrows(UnsupportedOperationException.class, () -> queue.addAll(Arrays.asList("another")));
+        assertThrows(UnsupportedOperationException.class, () -> queue.removeAll(Arrays.asList("test")));
+        assertThrows(UnsupportedOperationException.class, () -> queue.retainAll(Arrays.asList("test")));
+        assertThrows(UnsupportedOperationException.class, () -> queue.clear());
+    }
+
+    @Test
+    public void emptyIteratorNext() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
+        assertThrows(NoSuchElementException.class, () -> queue.iterator().next());
+    }
+
+    @Test
+    public void iteratorRemoveUnsupported() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
+        queue.add("one");
+        @SuppressWarnings("Var") Iterator<String> it = queue.iterator();
+        assertTrue(it.hasNext());
+        it.next();
+        assertThrows(UnsupportedOperationException.class, () -> it.remove());
+    }
+}


### PR DESCRIPTION
https://jules.google made this! 🔮 🚀 

This commit incorporates feedback and further refines the local CircularFifoQueue implementation:

- Moved CircularFifoQueue from ch.vorburger.exec.internal to ch.vorburger.exec.
- Changed CircularFifoQueue visibility to package-private.
- Updated copyright year to 2025 and added Jules (jules.google.com) as an author.
- Implemented `size()` and `isEmpty()` methods in CircularFifoQueue.
- Added comprehensive unit tests for CircularFifoQueue, covering initialization, add, full, rolling behavior, iterator, size, isEmpty, maxSize=1, null handling, and unsupported operations.
- Removed the now-empty ch.vorburger.exec.internal package.

All existing and new tests pass.

Fixes #263.