### PR TITLE
fix: upgrade error-prone to 2.49.0 and fix new compilation warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <error-prone.version>2.48.0</error-prone.version>
+    <error-prone.version>2.49.0</error-prone.version>
   </properties>
 
   <build>

--- a/src/test/java/ch/vorburger/exec/CircularFifoQueueTest.java
+++ b/src/test/java/ch/vorburger/exec/CircularFifoQueueTest.java
@@ -215,7 +215,8 @@ public class CircularFifoQueueTest {
     @Test
     public void emptyIteratorNext() {
         CircularFifoQueue<String> queue = new CircularFifoQueue<>(3);
-        assertThrows(NoSuchElementException.class, () -> queue.iterator().next());
+        Iterator<String> iterator = queue.iterator();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test

--- a/src/test/java/ch/vorburger/exec/ManagedProcessTest.java
+++ b/src/test/java/ch/vorburger/exec/ManagedProcessTest.java
@@ -55,9 +55,7 @@ public class ManagedProcessTest {
         SomeSelfTerminatingExec exec = someSelfTerminatingFailingExec(listener, false);
         assertThrows(
                 ManagedProcessException.class,
-                () -> {
-                    exec.proc.startAndWaitForConsoleMessageMaxMs(exec.msgToWaitFor, 1000);
-                });
+                () -> exec.proc.startAndWaitForConsoleMessageMaxMs(exec.msgToWaitFor, 1000));
         assertEquals(Integer.MIN_VALUE, listener.expectedExitValue);
         assertNotEquals(Integer.MIN_VALUE, listener.failureExitValue);
         assertNotNull(listener.t);


### PR DESCRIPTION
This PR upgrades error-prone to version 2.49.0 and resolves the new compilation warnings introduced by the update. Specifically:
- Fixed `AssertThrowsMinimizer` warning in `CircularFifoQueueTest.java` by extracting iterator creation outside of the `assertThrows` block.
- Fixed `AssertThrowsBlockToExpression` warning in `ManagedProcessTest.java` by replacing the block lambda with an expression lambda within `assertThrows`.

---
*PR created automatically by Jules for task [7102778353104035930](https://jules.google.com/task/7102778353104035930) started by @vorburger*